### PR TITLE
Update extension initialize method.

### DIFF
--- a/mdx_gfm/__init__.py
+++ b/mdx_gfm/__init__.py
@@ -6,8 +6,8 @@ from markdown.extensions.nl2br import Nl2BrExtension
 
 from mdx_partial_gfm import PartialGithubFlavoredMarkdownExtension
 
-def makeExtension(configs=None):
-    return GithubFlavoredMarkdownExtension(configs=configs)
+def makeExtension(*args, **kwargs):
+    return GithubFlavoredMarkdownExtension(*args, **kwargs)
 
 class GithubFlavoredMarkdownExtension(PartialGithubFlavoredMarkdownExtension):
     """An extension that's as compatible as possible with GFM.

--- a/mdx_partial_gfm/__init__.py
+++ b/mdx_partial_gfm/__init__.py
@@ -10,7 +10,7 @@ from markdown.extensions.tables import TableExtension
 import gfm
 
 def makeExtension(*args, **kwargs):
-    return GithubFlavoredMarkdownExtension(*args, **kwargs)
+    return PartialGithubFlavoredMarkdownExtension(*args, **kwargs)
 
 class PartialGithubFlavoredMarkdownExtension(Extension):
     """An extension that's as compatible as possible with GFM.

--- a/mdx_partial_gfm/__init__.py
+++ b/mdx_partial_gfm/__init__.py
@@ -9,8 +9,8 @@ from markdown.extensions.tables import TableExtension
 
 import gfm
 
-def makeExtension(configs=None):
-    return PartialGithubFlavoredMarkdownExtension(configs=configs)
+def makeExtension(*args, **kwargs):
+    return GithubFlavoredMarkdownExtension(*args, **kwargs)
 
 class PartialGithubFlavoredMarkdownExtension(Extension):
     """An extension that's as compatible as possible with GFM.


### PR DESCRIPTION
I met the error working with Python-Markdown 2.5.2.

```
  File "/path/to/venv/local/lib/python2.7/site-packages/markdown/extensions/__init__.py", line 36, in __init__
    self.setConfigs(kwargs.pop('configs', {}))
  File "/path/to/venv/local/lib/python2.7/site-packages/markdown/extensions/__init__.py", line 75, in setConfigs
    for key, value in items:
TypeError: 'NoneType' object is not iterable
```

I've created a pull request for Python-Markdown, but it was not merge.

https://github.com/waylan/Python-Markdown/pull/385

This pull request fix this error and deprecated usage.